### PR TITLE
Add plugin manifests so /plugin marketplace add works

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "cc4-marketing",
+  "description": "Claude Code for Marketers — CM (Compounding Marketing) and CF (Content Factory) plugins",
+  "owner": {
+    "name": "cc4-marketing",
+    "email": "support@cc4.marketing"
+  },
+  "plugins": [
+    {
+      "name": "cm",
+      "description": "Compounding Marketing — plan, execute, and review campaigns with persona reviewers and brand-voice checks",
+      "category": "productivity",
+      "source": "./plugins/cm"
+    },
+    {
+      "name": "cf",
+      "description": "Content Factory — batch-generate, repurpose, and schedule content across blogs, email, social, and video",
+      "category": "productivity",
+      "source": "./plugins/cf"
+    }
+  ]
+}

--- a/plugins/cf/.claude-plugin/plugin.json
+++ b/plugins/cf/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "cf",
+  "version": "0.1.0",
+  "description": "Content Factory — batch-generate, repurpose, and schedule content across blogs, email, social, and video",
+  "license": "MIT"
+}

--- a/plugins/cm/.claude-plugin/plugin.json
+++ b/plugins/cm/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "cm",
+  "version": "0.1.0",
+  "description": "Compounding Marketing — plan, execute, and review campaigns with persona reviewers and brand-voice checks",
+  "license": "MIT"
+}


### PR DESCRIPTION
Fixes #27.

Adds the three manifest files Claude Code's plugin loader requires:

- `.claude-plugin/marketplace.json` — declares the marketplace and lists `cm` + `cf`
- `plugins/cm/.claude-plugin/plugin.json` — `cm` plugin manifest
- `plugins/cf/.claude-plugin/plugin.json` — `cf` plugin manifest

### Problem

Without these, the README install flow fails:

```
/plugin marketplace add https://github.com/cc4-marketing/cc4.marketing
# Error: Marketplace file not found at .../.claude-plugin/marketplace.json

/plugin install cm@cc4.marketing
# Plugin "cm" not found in any marketplace
```

### After this PR

```
/plugin marketplace add https://github.com/cc4-marketing/cc4.marketing
/plugin install cm@cc4-marketing
/plugin install cf@cc4-marketing
/reload-plugins
```

Both plugins install and load cleanly.

### Heads-up on README

The marketplace name declared in `marketplace.json` is `cc4-marketing` (hyphen), so the install command becomes `cm@cc4-marketing` rather than `cm@cc4.marketing` as currently shown in the README. Happy to fix the README in this PR too if preferred — left it out to keep the diff minimal.